### PR TITLE
Make rows clickable

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,35 @@ or in sass
 @import "table_for"
 ```
 
+And JS in your `application.js` file:
+
+```
+//
+//= require table_for
+//
+```
+
 ## Usage
 
 To get started, just use the `table_for_for` helper. Here's an example:
 
 ```erb
 <%= table_for Model, @collection %>
+```
+
+#### Clickable rows
+
+To make rows clickable just add corresponding option to `table_for` helper:
+
+```erb
+<%= table_for Model, @collection, options: { clickable: true } %>
+```
+
+It builds a call to a named RESTful route for a given record from a collection.
+Also, you can specify your own URI by passing `row_uri` option:
+
+```erb
+<%= table_for Model, @collection, options: { clickable: true, row_uri: "http://example.com" } %>
 ```
 
 ### Customizing

--- a/app/assets/javascripts/table_for.js
+++ b/app/assets/javascripts/table_for.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const wrapper = document.querySelector(".table-for-wrapper");
+  if (wrapper) {
+    wrapper.addEventListener('click', function(event) {
+      const tr = event.target.closest("tr");
+      if (tr && tr.dataset.href) {
+        window.location = tr.dataset.href
+      }
+    });
+  }
+});

--- a/app/assets/stylesheets/table_for.scss.erb
+++ b/app/assets/stylesheets/table_for.scss.erb
@@ -1,5 +1,9 @@
 $table-for-breakpoint: <%= CtTableFor.table_for_breakpoint %> !default;
 
+tr[data-href] {
+  cursor: pointer;
+}
+
 @media (max-width: $table-for-breakpoint) {
   // table as cards
   .table-for {

--- a/app/helpers/ct_table_for/application_helper.rb
+++ b/app/helpers/ct_table_for/application_helper.rb
@@ -62,7 +62,9 @@ module CtTableFor
         if collection.present?
           custom_tr_class = options[:tr_class].present? ? %Q{class="#{options[:tr_class]}"} : ""
           collection.each do |record|
-            html << %Q{<tr data-colection-id="#{record.try(:id)}" #{custom_tr_class}>}
+            html << %Q{
+              <tr data-colection-id="#{record.try(:id)}" #{custom_tr_class} #{data_href_for(record, options)}>
+            }
               table_for_attributes(model, options).each do |attribute|
                 attribute, *params = attribute.split(":")
                 html << table_for_cell( model, record, attribute, cell_options: params )
@@ -79,6 +81,11 @@ module CtTableFor
         end
       html << %Q{</tbody>}
       html.html_safe
+    end
+
+    def data_href_for(record, options)
+      return unless options[:clickable]
+      "data-href=" << (options[:row_uri] && uri?(options[:row_uri]) ? options[:row_uri] : polymorphic_url(record))
     end
 
     def table_for_cell model, record, attribute, cell_options: {}


### PR DESCRIPTION
This PR adds an ability to make table rows clickable.
To do it just pass `clickable: true` option to the `table_for` helper. It builds a call to a named RESTful route for a given record from a collection.
Also, you can specify your own URI by passing `row_uri` option to the `table_for` helper. 