### PR TITLE
Added ancestors and method to custom actions

### DIFF
--- a/app/helpers/ct_table_for/application_helper.rb
+++ b/app/helpers/ct_table_for/application_helper.rb
@@ -215,11 +215,19 @@ module CtTableFor
 
     def button_for_custom_action record, options, extras
       parsed_extras = parse_extras(extras)
-      if options[:actions][:icons] != false
+      if parsed_extras[:icons] != false
         label = %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{parsed_extras[:icon]}"></i>}
       end
+      ancestors_list = parsed_extras[:ancestors].presence || ""
+      ancestors = ancestors_list.split(",").map do |ancestor|
+        record.send(ancestor)
+      end
       custom_action_class = %Q{#{CtTableFor.table_for_default_action_base_class} #{parsed_extras[:class]}}
-      link_to(label.html_safe, polymorphic_path([parsed_extras[:link], record]), class: custom_action_class, title: parsed_extras[:title])
+      link_to(label.html_safe,
+              polymorphic_path([parsed_extras[:link], *ancestors, record]),
+              class: custom_action_class,
+              method: parsed_extras[:method],
+              title: parsed_extras[:title])
     end
 
     def uri?(string)

--- a/app/helpers/ct_table_for/application_helper.rb
+++ b/app/helpers/ct_table_for/application_helper.rb
@@ -176,29 +176,19 @@ module CtTableFor
       html << %Q{<td data-link-enabled="false">}
         html << %Q{<div class="btn-group btn-group-sm" role="group" aria-label="#{I18n.t(:actions, scope: [:table_for]).capitalize}">}
         nesting = (options[:actions][:premodel] || []) + [record]
-        buttons, *btn_options = options[:actions][:buttons].split(":")
-        buttons.each do |action|
+        buttons = options[:actions][:buttons].map{ |b| b.split("|")}
+        buttons.each do |action, *extras|
           return "" if defined?(CanCanCan) and cannot?(action, record)
-          label = I18n.t(action.to_sym, scope: [:table_for, :buttons]).capitalize
-          custom_action_class = %Q{#{CtTableFor.table_for_default_action_base_class} #{options.dig(:btn_class, action.to_sym) || CtTableFor.table_for_action_class[action.to_sym]}}
           case action.to_sym
           when :show
-            if options[:actions][:icons] != false
-              label = %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{CtTableFor.table_for_action_icons[:show]}"></i>}
-            end
-            html << link_to(label.html_safe, polymorphic_path(nesting), class: custom_action_class)
+            html << link_to(label_for_action(action, options[:actions][:icons]).html_safe, polymorphic_path(nesting), class: class_for_action(action, options))
           when :edit
-            if options[:actions][:icons] != false
-              label = %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{CtTableFor.table_for_action_icons[:edit]}"></i>}
-            end
-            html << link_to(label.html_safe, edit_polymorphic_path(nesting), class: custom_action_class)
+            html << link_to(label_for_action(action, options[:actions][:icons]).html_safe, edit_polymorphic_path(nesting), class: class_for_action(action, options))
           when :destroy
-            if options[:actions][:icons] != false
-              label = %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{CtTableFor.table_for_action_icons[:destroy]}"></i>}
-            end
-            html << link_to(label.html_safe, polymorphic_path(nesting),
-                    method: :delete, class: custom_action_class,
-                    data: { confirm: I18n.t('table_for.messages.are_you_sure').capitalize })
+            html << link_to(label_for_action(action, options[:actions][:icons]).html_safe, polymorphic_path(nesting),
+                            method: :delete, class: class_for_action(action, options), data: { confirm: I18n.t('table_for.messages.are_you_sure').capitalize })
+          when :custom
+            html << button_for_custom_action(record, options, extras)
           else
             # TODO:
             # nesting_custom = nesting + btn_options[0]
@@ -211,6 +201,27 @@ module CtTableFor
       html.html_safe
     end
 
+    def label_for_action action, icons = true
+      label = I18n.t(action.to_sym, scope: [:table_for, :buttons]).capitalize
+      if icons != false
+        label = %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{CtTableFor.table_for_action_icons[action.to_sym]}"></i>}
+      end
+      label
+    end
+
+    def class_for_action action, options
+      %Q{#{CtTableFor.table_for_default_action_base_class} #{options.dig(:btn_class, action.to_sym) || CtTableFor.table_for_action_class[action.to_sym]}}
+    end
+
+    def button_for_custom_action record, options, extras
+      parsed_extras = parse_extras(extras)
+      if options[:actions][:icons] != false
+        label = %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{parsed_extras[:icon]}"></i>}
+      end
+      custom_action_class = %Q{#{CtTableFor.table_for_default_action_base_class} #{parsed_extras[:class]}}
+      link_to(label.html_safe, polymorphic_path([parsed_extras[:link], record]), class: custom_action_class, title: parsed_extras[:title])
+    end
+
     def uri?(string)
       # http://ruby-doc.org/stdlib-2.4.0/libdoc/uri/rdoc/URI.html
       uri = URI.parse(string)
@@ -219,6 +230,10 @@ module CtTableFor
       false
     rescue URI::InvalidURIError
       false
+    end
+
+    def parse_extras(extras)
+      Hash[extras.collect { |extra| [extra.split(":").first, extra.split(":").last] } ].with_indifferent_access
     end
   end
 end

--- a/app/helpers/ct_table_for/application_helper.rb
+++ b/app/helpers/ct_table_for/application_helper.rb
@@ -215,8 +215,11 @@ module CtTableFor
 
     def button_for_custom_action record, options, extras
       parsed_extras = parse_extras(extras)
-      if parsed_extras[:icons] != false
-        label = %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{parsed_extras[:icon]}"></i>}
+      # `icons` is a Boolean-String option to limit `icon` option
+      label = if parsed_extras[:icons].to_s == "false"
+        parsed_extras[:title].presence || ""
+      else
+        %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{parsed_extras[:icon]}"></i>}
       end
       ancestors_list = parsed_extras[:ancestors].presence || ""
       ancestors = ancestors_list.split(",").map do |ancestor|

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,17 +66,29 @@
     <p> The system also allows the configuration of custom buttons according to the needs. In order to do it, we must follow a pre-established format: <code>custom|key1:value1|key2:value2|...</code></p>
     <p> The possible values are: </p>
     <ul>
+      <li><i>icons</i>: boolean, to determine the use of an icon or title option for showing</li>
       <li><i>icon</i>: key name of the icon to be used, for example <i>eye</i>, <i>trash</i> o <i>gear</i></li>
       <li><i>class</i>: class to add to the icon</li>
       <li><i>title</i>: allows to add a floating text (tooltip)</li>
-      <li><i>link</i>: action link. In this first version only GET actions are allowed over the same table object. </li>
+      <li><i>link</i>: action link.</li>
+      <li><i>method</i>: method of link. You can pass whatever method you want to be used in the link: GET, POST,...</li>
+      <li><i>ancestors</i>: ancestor's object methods to be used to fill up link. Very usefull for nested link generation.</li>
     </ul>
     <p> For example:</p>
-    <code>
-      <%= table_for User, @users, options:
-      {attributes: %w(id type),
-        actions: {buttons: "custom|icon:plus|class:btn-success|link:new_page_bo_admin|title:New page", premodel: [:bo, :admin]}} %>
-    </code>
+    <p>
+      <code>
+        <%= table_for User, @users, options:
+        {attributes: %w(id type),
+          actions: {buttons: "custom|icon:plus|class:btn-success|link:new_page_bo_admin|title:New page", premodel: [:bo, :admin]}} %>
+      </code>
+    </p>
+    <p>
+      <code>
+        <%= table_for Comment, @comments, options:
+        {attributes: %w(id),
+          actions: {buttons: "custom|icons:false|class:btn-error|link:bo_admin|ancestors:communication,user|method:delete|title:Delete comment", premodel: [:bo, :admin]}} %>
+      </code>
+    </p>
   </div>
 </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
 <body>
 <div class="alert alert-info">
   <p>Has d'incloure al <code>Gemfile</code>:<br>
-  <code>gem 'ct_table_for', '~> 0.1.14.beta'</code>
+  <code>gem 'ct_table_for', '~> 0.1.15.beta'</code>
   </p>
 </div>
 <div class="box">

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,7 +62,25 @@
     <h4>Accions amb texte</h4>
     <p> Per defecte, en les accions es mostren les icones corresponents, però si volem que el que es mostri és el texte haurem d'incloure al `hash` d'actions: <code>icons: false</code> </p>
     <p> A més a més de passar com a opcions el hash d'accions, hem de passar la opció <code>icons: true</code></p>
-    <%= table_for User, @users, options: {attributes: %w( id type active confirmed_at name surnames email), actions: {buttons: %w(show edit destroy), icons: false, premodel: [:bo, :admin]}} %>
+    <p>
+      <code><%= table_for User, @users, options: {attributes: %w( id type active confirmed_at name surnames email), actions: {buttons: %w(show edit destroy), icons: false, premodel: [:bo, :admin]}} %></code>
+    </p>
+
+    <h4>Accions customitzades</h4>
+    <p> El sistema també permet la configuració de botons customitzats segons necessitats. Per fer-ho, cal seguir un format pre-establert, que segueix: <code>custom|key1:value1|key2:value2|...</code></p>
+    <p> Els valors possibles son:</p>
+    <ul>
+      <li><i>icon</i>: nom clau de la icona a fer servir, per exemple <i>eye</i>, <i>trash</i> o <i>gear</i></li>
+      <li><i>class</i>: classe a afegir a la icona</li>
+      <li><i>title</i>: permet afegir un text flotant (tooltip)</li>
+      <li><i>link</i>: link de la acció. En aquesta primera versió noḿes es permeten accions GET sobre el mateix objecte de la taula</li>
+    </ul>
+    <p> Per exemple:</p>
+    <code>
+      <%= table_for User, @users, options:
+      {attributes: %w(id type),
+        actions: {buttons: "custom|icon:plus|class:btn-success|link:new_page_bo_admin|title:New page", premodel: [:bo, :admin]}} %>
+    </code>
   </div>
 </div>
 

--- a/lib/ct_table_for/version.rb
+++ b/lib/ct_table_for/version.rb
@@ -1,3 +1,3 @@
 module CtTableFor
-  VERSION = '0.1.14.beta'
+  VERSION = '0.1.15.beta'
 end


### PR DESCRIPTION
Added more logic to custom actions.

**method**: for `post`, `destroy` or other actions, enabling 
**ancestors**: polymorphic_url needs records to perform nesting paths. This new parameter adds the logic to search for record's related objects.