### PR TITLE
fix table headers for associated model with ransack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## version 0.1.14.beta to be released
+## version 1.0.2 to be released
 
 - ...
+
+## version 1.0.1
+
+- fix table headers for associated model with ransack
 
 ## version 0.1.13.beta
 

--- a/app/helpers/ct_table_for/application_helper.rb
+++ b/app/helpers/ct_table_for/application_helper.rb
@@ -49,7 +49,11 @@ module CtTableFor
             html << %Q{<th>}
               attribute, *params = attribute.split(":")
               html << if defined?(Ransack) and params.include? "sortable"
-                sort_link(@q, attribute, I18n.t("#{attribute}", scope: [:activerecord, :attributes, model.to_s.underscore]).capitalize )
+                if params.length == 1
+                  sort_link(@q, attribute, I18n.t("#{attribute}", scope: [:activerecord, :attributes, model.to_s.underscore]).capitalize )
+                else
+                  sort_link(@q, "#{attribute}_#{params.first}", I18n.t("#{attribute.to_s.underscore}_#{params.first}", scope: [:activerecord, :attributes, model.to_s.underscore]).capitalize )
+                end
               else
                 model.human_attribute_name("#{attribute}")
               end

--- a/app/helpers/ct_table_for/application_helper.rb
+++ b/app/helpers/ct_table_for/application_helper.rb
@@ -49,10 +49,10 @@ module CtTableFor
             html << %Q{<th>}
               attribute, *params = attribute.split(":")
               html << if defined?(Ransack) and params.include? "sortable"
-                if params.length == 1
-                  sort_link(@q, attribute, I18n.t("#{attribute}", scope: [:activerecord, :attributes, model.to_s.underscore]).capitalize )
-                else
+                if params.length > 1 && !params.include?("l")
                   sort_link(@q, "#{attribute}_#{params.first}", I18n.t("#{attribute.to_s.underscore}_#{params.first}", scope: [:activerecord, :attributes, model.to_s.underscore]).capitalize )
+                else
+                  sort_link(@q, attribute, I18n.t("#{attribute}", scope: [:activerecord, :attributes, model.to_s.underscore]).capitalize )
                 end
               else
                 model.human_attribute_name("#{attribute}")

--- a/lib/ct_table_for/version.rb
+++ b/lib/ct_table_for/version.rb
@@ -1,3 +1,3 @@
 module CtTableFor
-  VERSION = '1.0.0'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
Add functionality so that when ct_table_for has an associated model field and this one must be ordered with Ransack, it works correctly. 
From this:
![Screenshot from 2019-05-23 12-41-36](https://user-images.githubusercontent.com/28536082/58247920-1176b900-7d5b-11e9-9bda-1341345fd3d5.png)

To this
![Screenshot from 2019-05-23 13-01-57](https://user-images.githubusercontent.com/28536082/58247907-07ed5100-7d5b-11e9-91bc-186a734ed1c6.png)
