### PR TITLE
Upgrade to Rails 6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
+# Changelog
+
+## version 1.1.0 to be released
+
+- Upgrade to Rails 6.1
+- [FEATURE] Change style given a method (#25)
+- Removed comma separator enforcer
+- Now forces locale settings on numbers
+- Added documentation
+- Added comma separator option to numbers
+
 ## version 1.0.5 to be released
 
-- ...
+- Delete rails 5 restriction (#22)
 
 ## version 1.0.4
 

--- a/app/assets/stylesheets/table_for.scss.erb
+++ b/app/assets/stylesheets/table_for.scss.erb
@@ -1,4 +1,4 @@
-$table-for-breakpoint: <%= CtTableFor.table_for_breakpoint %> !default;
+$table-for-breakpoint: <%= CtTableFor.config.table_for_breakpoint %> !default;
 
 @media (max-width: $table-for-breakpoint) {
   // table as cards

--- a/app/helpers/ct_table_for/application_helper.rb
+++ b/app/helpers/ct_table_for/application_helper.rb
@@ -29,8 +29,8 @@ module CtTableFor
 
     def table_for model, collection, options: {}
       custom_id = options[:id].present? ? %Q{id="#{options[:id]}"} : ""
-      html = %Q{<div class="table-for-wrapper #{CtTableFor.table_for_wrapper_default_class}">}
-        html << %Q{<table #{custom_id} class="table-for #{CtTableFor.table_for_default_class} #{options[:class]} #{("table-clickable") if options[:clickable]}">}
+      html = %Q{<div class="table-for-wrapper #{CtTableFor.config.table_for_wrapper_default_class}">}
+        html << %Q{<table #{custom_id} class="table-for #{CtTableFor.config.table_for_default_class} #{options[:class]} #{("table-clickable") if options[:clickable]}">}
           html << table_for_header(model, has_actions: options[:actions].present?, options: options)
           html << table_for_content(model, collection, options: options)
         html << %Q{</table>}
@@ -111,7 +111,7 @@ module CtTableFor
                 nil
               end
 
-      html << %Q{<td data-title="#{model.human_attribute_name("#{attribute}")}" class="#{CtTableFor.table_for_td_default_prefix_class}-#{attribute}">}
+      html << %Q{<td data-title="#{model.human_attribute_name("#{attribute}")}" class="#{CtTableFor.config.table_for_td_default_prefix_class}-#{attribute}">}
         case value
         when NilClass
           html << %Q{<i class="fa fa-minus text-muted"></i>}
@@ -121,7 +121,7 @@ module CtTableFor
           if cell_options.include? "currency"
             html << number_to_currency(value)
           elsif cell_options.include? "percentage"
-            html << number_to_percentage(value, precision: CtTableFor.table_for_numeric_percentage_precision)
+            html << number_to_percentage(value, precision: CtTableFor.config.table_for_numeric_percentage_precision)
           else
             html << %Q{#{number_with_delimiter(value)}}
           end
@@ -153,9 +153,9 @@ module CtTableFor
               html << value.to_s
             else
               html << value.to_s.truncate(
-                CtTableFor.table_for_truncate_length,
-                separator: CtTableFor.table_for_truncate_separator,
-                omission: CtTableFor.table_for_truncate_omission
+                CtTableFor.config.table_for_truncate_length,
+                separator: CtTableFor.config.table_for_truncate_separator,
+                omission: CtTableFor.config.table_for_truncate_omission
               )
             end
           end
@@ -168,7 +168,7 @@ module CtTableFor
       html = ""
       size = cell_options.select{ |opt| ["thumb", "original", "small", "medium"].include? opt }.first || "thumb"
 
-      html << image_tag(record.send(attribute).url(size), class: CtTableFor.table_for_cell_for_image_image_class, style: "max-height: 100px;")
+      html << image_tag(record.send(attribute).url(size), class: CtTableFor.config.table_for_cell_for_image_image_class, style: "max-height: 100px;")
       html.html_safe
     end
 
@@ -180,7 +180,7 @@ module CtTableFor
     def table_for_actions(record, options: {} )
       return "" if options[:actions].blank?
       html = ""
-      html << %Q{<td data-link-enabled="false" class="#{CtTableFor.table_for_td_default_prefix_class}-actions">}
+      html << %Q{<td data-link-enabled="false" class="#{CtTableFor.config.table_for_td_default_prefix_class}-actions">}
         html << %Q{<div class="btn-group btn-group-sm" role="group" aria-label="#{I18n.t(:actions, scope: [:table_for]).capitalize}">}
         nesting = (options[:actions][:premodel] || []) + [record]
         buttons = options[:actions][:buttons].map{ |b| b.split("|")}
@@ -201,7 +201,7 @@ module CtTableFor
             else
               # TODO:
               # nesting_custom = nesting + btn_options[0]
-              # label = icon CtTableFor.table_for_action_icons[:custom] if options[:actions][:icons] != false and defined?(FontAwesome)
+              # label = icon CtTableFor.config.table_for_action_icons[:custom] if options[:actions][:icons] != false and defined?(FontAwesome)
               # html << link_to(label, polymorphic_path(nesting_custom), class: "btn btn-default btn-sm")
             end
           end
@@ -214,13 +214,13 @@ module CtTableFor
     def label_for_action action, icons = true
       label = I18n.t(action.to_sym, scope: [:table_for, :buttons]).capitalize
       if icons != false
-        label = %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{CtTableFor.table_for_action_icons[action.to_sym]}"></i>}
+        label = %Q{<i class="#{CtTableFor.config.table_for_icon_font_base_class} #{CtTableFor.config.table_for_icon_font_base_class}-#{CtTableFor.config.table_for_action_icons[action.to_sym]}"></i>}
       end
       label
     end
 
     def class_for_action action, options
-      %Q{#{CtTableFor.table_for_default_action_base_class} #{options.dig(:btn_class, action.to_sym) || CtTableFor.table_for_action_class[action.to_sym]}}
+      %Q{#{CtTableFor.config.table_for_default_action_base_class} #{options.dig(:btn_class, action.to_sym) || CtTableFor.config.table_for_action_class[action.to_sym]}}
     end
 
     def button_for_custom_action record, options, extras
@@ -229,13 +229,13 @@ module CtTableFor
       label = if parsed_extras[:icons].to_s == "false"
         parsed_extras[:title].presence || ""
       else
-        %Q{<i class="#{CtTableFor.table_for_icon_font_base_class} #{CtTableFor.table_for_icon_font_base_class}-#{parsed_extras[:icon]}"></i>}
+        %Q{<i class="#{CtTableFor.config.table_for_icon_font_base_class} #{CtTableFor.config.table_for_icon_font_base_class}-#{parsed_extras[:icon]}"></i>}
       end
       ancestors_list = parsed_extras[:ancestors].presence || ""
       ancestors = ancestors_list.split(",").map do |ancestor|
         record.send(ancestor)
       end
-      custom_action_class = %Q{#{CtTableFor.table_for_default_action_base_class} #{parsed_extras[:class]}}
+      custom_action_class = %Q{#{CtTableFor.config.table_for_default_action_base_class} #{parsed_extras[:class]}}
       link_to(label.html_safe,
               polymorphic_path([parsed_extras[:link], *ancestors, record]),
               class: custom_action_class,

--- a/ct_table_for.gemspec
+++ b/ct_table_for.gemspec
@@ -7,8 +7,8 @@ require "ct_table_for/version"
 Gem::Specification.new do |s|
   s.name        = "ct_table_for"
   s.version     = CtTableFor::VERSION
-  s.authors     = ["Agustí B.R.", "Isaac Massot", "Marc Reniu"]
-  s.email       = ["agusti.br@coditramuntana.com", "issac.mg@coditramuntana.com", "marc.rs@coditramuntana.com"]
+  s.authors     = ["Agustí B.R.", "Isaac Massot", "Marc Reniu", "Oliver Valls"]
+  s.email       = ["info@coditramuntana.com"]
   s.homepage    = "https://github.com/CodiTramuntana/ct_table_for"
   s.summary     = "Rails table builder that makes it easy to do responsive tables ActiveRecord"
   s.description = "table_for is a rails table builder given an ActiveRecord"
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 5.0"
+  s.add_dependency "rails", ">= 6.1"
 end

--- a/lib/ct_table_for/engine.rb
+++ b/lib/ct_table_for/engine.rb
@@ -1,5 +1,5 @@
 module CtTableFor
-  class << self
+  class Config
     mattr_accessor :table_for_default_class
     mattr_accessor :table_for_wrapper_default_class
     mattr_accessor :table_for_default_action_base_class
@@ -29,9 +29,13 @@ module CtTableFor
     self.table_for_td_default_prefix_class = "td-item"
   end
 
+  def self.config
+    @config||= Config.new
+  end
+
   # this function maps the vars from your app into your engine
   def self.setup(&block)
-    yield self
+    yield config
   end
 
   class Engine < ::Rails::Engine

--- a/lib/ct_table_for/version.rb
+++ b/lib/ct_table_for/version.rb
@@ -1,3 +1,3 @@
 module CtTableFor
-  VERSION = '1.0.5'
+  VERSION = '1.1.0'
 end


### PR DESCRIPTION
Rails 6.1 makes `mattr_accessor' to error in [this](https://github.com/rails/rails/pull/38144) change if it is called on a singleton class, which was our case.

This PR refactors this gem to make it compatible with Rails 6.1.